### PR TITLE
Translate function fix moves.c

### DIFF
--- a/moves.c
+++ b/moves.c
@@ -52,7 +52,7 @@ t_localisation translate(t_localisation loc, t_move move)
      *  - y grows to the bottom with step of +1
      *  - the origin (x=0, y=0) is at the top left corner
      */
-    t_position res;
+    t_position res = loc.pos;
     switch (move) {
         case F_10:
             switch (loc.ori) {


### PR DESCRIPTION
Fixed an issue where translate function would created a new empty position and copy the modified x or y coordinate but wouldn't copy the other so he became NULL when returned.