### PR TITLE
Enhance Cross-Platform Portability by Refactoring Includes and File Path Handling

### DIFF
--- a/main.c
+++ b/main.c
@@ -2,7 +2,17 @@
 #include "map.h"
 
 int main() {
-    t_map map = createMapFromFile("..\\maps\\example1.map");
+    t_map map;
+
+    // The following preprocessor directive checks if the code is being compiled on a Windows system.
+    // If either _WIN32 or _WIN64 is defined, it means we are on a Windows platform.
+    // On Windows, file paths use backslashes (\), hence we use the appropriate file path for Windows.
+#if defined(_WIN32) || defined(_WIN64)
+    map = createMapFromFile("..\\maps\\example1.map");
+#else
+    map = createMapFromFile("../maps/example1.map");
+#endif
+
     printf("Map created with dimensions %d x %d\n", map.y_max, map.x_max);
     for (int i = 0; i < map.y_max; i++)
     {

--- a/stack.c
+++ b/stack.c
@@ -2,7 +2,7 @@
 // Created by flasque on 19/10/2024.
 //
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <assert.h>
 #include "stack.h"
 


### PR DESCRIPTION
This pull request improves the portability of the project by addressing two key areas:

1. **Refactor include directive for portability**:
   - Replaced the `#include <malloc.h>` directive in `stack.c` with `#include <stdlib.h>`. This change ensures compatibility across different operating systems, as some platforms (such as macOS) do not include `malloc.h`. The necessary memory allocation functions are provided by `stdlib.h`, making the code more universally compatible for all students.

2. **Add cross-platform support for file paths in `main.c`**:
   - Updated the file path handling in `main.c` to differentiate between Windows and Unix-based systems. A preprocessor directive (`#ifdef _WIN32`) was added to use backslashes for Windows file paths and forward slashes for Unix-like systems. This modification ensures that the correct map file is loaded, regardless of the operating system the students are using.