### PR TITLE
Fix uninitialized variable in rotate function by adding default case

### DIFF
--- a/moves.c
+++ b/moves.c
@@ -40,6 +40,7 @@ t_orientation rotate(t_orientation ori, t_move move)
             rst=2;
             break;
         default:
+            rst=0;
             break;
     }
     return (ori+rst)%4;


### PR DESCRIPTION
The rst variable wasn't initialized 
So if the given move wasn't a T_LEFT, T_RIGHT or U_TURN the return of ori+rst can't work