### PR TITLE
Fixed infinite loop when computing costs

### DIFF
--- a/map.c
+++ b/map.c
@@ -188,7 +188,6 @@ void calculateCosts(t_map map)
         }
     }
 
-    free(queue.values);
 
     return;
 }
@@ -301,21 +300,4 @@ void displayMap(t_map map)
 
     }
     return;
-}
-
-void free_map(t_map *map)
-{
-    int ydim = map->y_max;
-    for (int i = 0; i < ydim; i++)
-    {
-        free(map->soils[i]);
-    }
-    free(map->soils);
-    map->soils = NULL;
-    for (int i = 0; i < ydim; i++)
-    {
-        free(map->costs[i]);
-    }
-    free(map->costs);
-    map->costs = NULL;
 }

--- a/map.c
+++ b/map.c
@@ -72,6 +72,7 @@ void removeFalseCrevasses(t_map map)
     while (!over)
     {
         int min_cost = COST_UNDEF;
+        int max_cost = 0;
         imin = map.y_max;
         jmin = map.x_max;
         for (int i=0; i<map.y_max; i++)
@@ -84,8 +85,14 @@ void removeFalseCrevasses(t_map map)
                     imin = i;
                     jmin = j;
                 }
+                if (map.soils[i][j] != CREVASSE && map.costs[i][j] > 10000 && map.costs[i][j] > max_cost)
+                {
+                    max_cost = map.costs[i][j];
+                }
+                
             }
         }
+
         if (imin < map.y_max && jmin < map.x_max)
         {
             // step 2 : calculate the costs of the neighbours of the position
@@ -115,7 +122,10 @@ void removeFalseCrevasses(t_map map)
                 min_neighbour = (map.costs[dp.y][dp.x] < min_neighbour) ? map.costs[dp.y][dp.x] : min_neighbour;
             }
             int self_cost = _soil_cost[map.soils[imin][jmin]];
+            int prev = map.costs[imin][jmin];
             map.costs[imin][jmin] = (min_neighbour + self_cost < map.costs[imin][jmin]) ? min_neighbour + self_cost : map.costs[imin][jmin];
+            if(prev == map.costs[imin][jmin])
+                map.costs[imin][jmin] = max_cost + 1;
         }
         else
         {
@@ -189,7 +199,6 @@ void calculateCosts(t_map map)
     }
 
     free(queue.values);
-
     return;
 }
 /* definition of exported functions */

--- a/map.c
+++ b/map.c
@@ -188,6 +188,7 @@ void calculateCosts(t_map map)
         }
     }
 
+    free(queue.values);
 
     return;
 }

--- a/map.c
+++ b/map.c
@@ -188,6 +188,7 @@ void calculateCosts(t_map map)
         }
     }
 
+    free(queue.values);
 
     return;
 }
@@ -300,4 +301,21 @@ void displayMap(t_map map)
 
     }
     return;
+}
+
+void free_map(t_map *map)
+{
+    int ydim = map->y_max;
+    for (int i = 0; i < ydim; i++)
+    {
+        free(map->soils[i]);
+    }
+    free(map->soils);
+    map->soils = NULL;
+    for (int i = 0; i < ydim; i++)
+    {
+        free(map->costs[i]);
+    }
+    free(map->costs);
+    map->costs = NULL;
 }

--- a/map.c
+++ b/map.c
@@ -305,17 +305,13 @@ void displayMap(t_map map)
 
 void free_map(t_map *map)
 {
-    int ydim = map->y_max;
-    for (int i = 0; i < ydim; i++)
+    for (int i = 0; i < map->y_max; i++)
     {
         free(map->soils[i]);
+        free(map->costs[i]);
     }
     free(map->soils);
     map->soils = NULL;
-    for (int i = 0; i < ydim; i++)
-    {
-        free(map->costs[i]);
-    }
     free(map->costs);
     map->costs = NULL;
 }

--- a/map.h
+++ b/map.h
@@ -55,4 +55,11 @@ t_map createMapFromFile(char *);
  */
 void displayMap(t_map);
 
+/**
+ * @brief free the map struct's arrays
+ * 
+ * @param map : a pointer to the map to be freed. Will be set to NULL.
+ */
+void free_map(t_map *map);
+
 #endif //UNTITLED1_MAP_H

--- a/map.h
+++ b/map.h
@@ -55,11 +55,4 @@ t_map createMapFromFile(char *);
  */
 void displayMap(t_map);
 
-/**
- * @brief free the map struct's arrays
- * 
- * @param map : a pointer to the map to be freed. Will be set to NULL.
- */
-void free_map(t_map *map);
-
 #endif //UNTITLED1_MAP_H

--- a/moves.c
+++ b/moves.c
@@ -40,6 +40,7 @@ t_orientation rotate(t_orientation ori, t_move move)
             rst=2;
             break;
         default:
+            rst=0;
             break;
     }
     return (ori+rst)%4;

--- a/moves.c
+++ b/moves.c
@@ -143,8 +143,8 @@ char *getMoveAsString(t_move move)
 t_localisation move(t_localisation loc, t_move move)
 {
     t_localisation new_loc;
-    new_loc.ori = rotate(loc.ori, move);
     new_loc = translate(loc, move);
+    new_loc.ori = rotate(loc.ori, move);
     return new_loc;
 }
 


### PR DESCRIPTION
Fixed the infinite loop when computing a cost of a tile that is surrounded by tiles with a cost higher than 10000.
The solution is to set it to the max cost of the map + 1, so that it will be updated later -- and so possibly when tiles around it aren't at a score of 10000+ anymore.

Fixed memory leak on map creation, and added a function to free a map.